### PR TITLE
OP-584 Prevent double API call

### DIFF
--- a/src/components/MapInteractive/index.js
+++ b/src/components/MapInteractive/index.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Route } from 'react-router-dom';
 import { isEqual } from 'lodash';
 
-import { getDevices, getDevice, initIoT, getCameraAreas } from '../../services/api/iot';
+import { getDevices, getDevice, getCameraAreas } from '../../services/api/iot';
 import { showAreas, showMarkers, toggleElement } from '../../services/iotmap';
 import categories from '../../static/categories';
 import amaps from '../../static/amaps.iife';
@@ -27,7 +27,6 @@ class Map extends React.Component {
   constructor(props) {
     super(props);
 
-    initIoT();
     this.map = null;
     this.state = {
       selection: {

--- a/src/services/api/iot.js
+++ b/src/services/api/iot.js
@@ -1,6 +1,7 @@
 import CONFIGURATION from 'shared/services/configuration/configuration';
 import { readPaginatedData } from '../datareader';
 
+
 let devices = null;
 
 export async function getDevices() {
@@ -13,10 +14,6 @@ export async function getDevice(id) {
   }
   const all = await devices;
   return all.find((element) => element.id === id);
-}
-
-export function initIoT() {
-  devices = getDevices();
 }
 
 export async function getCameraAreas() {

--- a/src/services/api/iot.js
+++ b/src/services/api/iot.js
@@ -1,7 +1,6 @@
 import CONFIGURATION from 'shared/services/configuration/configuration';
 import { readPaginatedData } from '../datareader';
 
-
 let devices = null;
 
 export async function getDevices() {


### PR DESCRIPTION
This PR prevents calling the API twice on app load. The `MapInteractive` component contained calls to `getDevices` in two locations.