### PR TITLE
[Draft] Add i18n to app components

### DIFF
--- a/internals/generators/index.js
+++ b/internals/generators/index.js
@@ -6,16 +6,16 @@
 
 const fs = require('fs');
 const path = require('path');
-// const componentGenerator = require('./component/index.js');
-// const containerGenerator = require('./container/index.js');
-// const languageGenerator = require('./language/index.js');
+const componentGenerator = require('./component/index.js');
+const containerGenerator = require('./container/index.js');
+const languageGenerator = require('./language/index.js');
 const dpComponentGenerator = require('./ams-component/index.js');
 const dpContainerGenerator = require('./ams-container/index.js');
 
 module.exports = (plop) => {
-  // plop.setGenerator('component', componentGenerator);
-  // plop.setGenerator('container', containerGenerator);
-  // plop.setGenerator('language', languageGenerator);
+  plop.setGenerator('component', componentGenerator);
+  plop.setGenerator('container', containerGenerator);
+  plop.setGenerator('language', languageGenerator);
   plop.setGenerator('ams-component', dpComponentGenerator);
   plop.setGenerator('ams-container', dpContainerGenerator);
   plop.addHelper('directory', (comp) => {

--- a/internals/scripts/extract-intl.js
+++ b/internals/scripts/extract-intl.js
@@ -15,7 +15,7 @@ const presets = pkg.babel.presets;
 const plugins = pkg.babel.plugins || [];
 
 const i18n = require('../../src/i18n');
-import { DEFAULT_LOCALE } from '../../src/containers/src/constants';
+import { DEFAULT_LOCALE } from '../../src/containers/App/constants';
 
 require('shelljs/global');
 

--- a/src/app.js
+++ b/src/app.js
@@ -88,6 +88,7 @@ if (!window.Intl) {
     .then(() => Promise.all([
       import('intl/locale-data/jsonp/en.js'),
       import('intl/locale-data/jsonp/nl.js'),
+      import('intl/locale-data/jsonp/da.js'),
     ]))
     .then(() => render(translationMessages))
     .catch((err) => {

--- a/src/components/MainMenu/__snapshots__/index.test.js.snap
+++ b/src/components/MainMenu/__snapshots__/index.test.js.snap
@@ -21,7 +21,7 @@ exports[`<MainMenu /> should render correctly 1`] = `
             >
               <FormattedMessage
                 defaultMessage="Home"
-                id="boilerplate.components.Header.home"
+                id="IoTRegister.components.Header.home"
                 values={Object {}}
               />
             </span>

--- a/src/components/MainMenu/messages.js
+++ b/src/components/MainMenu/messages.js
@@ -7,7 +7,7 @@ import { defineMessages } from 'react-intl';
 
 export default defineMessages({
   home: {
-    id: 'boilerplate.components.Header.home',
+    id: 'IoTRegister.components.Header.home',
     defaultMessage: 'Home',
   }
 });

--- a/src/components/MapLegend/index.js
+++ b/src/components/MapLegend/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { FormattedMessage } from 'react-intl';
+import { intlShape, injectIntl, FormattedMessage } from 'react-intl';
 import { Checkbox } from '../../shared/components/checkbox';
 
 import CollapseIcon from '../../images/icon-arrow-down.svg';
@@ -16,6 +16,7 @@ class MapLegend extends React.Component {
     super(props);
 
     this.state = { isLegendVisible: window.innerWidth > 576 };
+    this.intl = props.intl;
   }
 
   render() {
@@ -34,7 +35,7 @@ class MapLegend extends React.Component {
     return (
       <section
         id="map-legend"
-        aria-label={this.state.isLegendVisible ? 'Kaartlagen legenda, Kaartlagen verbergen' : 'Kaartlagen legenda, Kaartlagen tonen'}
+        aria-label={this.state.isLegendVisible ? this.intl.formatMessage({ ...messages.legendHide }) : this.intl.formatMessage({ ...messages.legendShow })}
         aria-expanded={this.state.isLegendVisible}
         className={`
           map-legend
@@ -44,7 +45,7 @@ class MapLegend extends React.Component {
         <button
           className="map-legend__header"
           onClick={() => this.setState({ isLegendVisible: !this.state.isLegendVisible })}
-          title={this.state.isLegendVisible ? 'Kaartlagen verbergen' : 'Kaartlagen tonen'}
+          title={this.state.isLegendVisible ? this.intl.formatMessage({ ...messages.hide }) : this.intl.formatMessage({ ...messages.show })}
         >
           <MapLayersIcon className="map-legend__header-icon" />
           <h4 className="map-legend__header-title" aria-hidden="true">
@@ -63,7 +64,8 @@ class MapLegend extends React.Component {
 
 MapLegend.propTypes = {
   categories: PropTypes.object,
-  onCategorieToggle: PropTypes.func
+  onCategorieToggle: PropTypes.func,
+  intl: intlShape.isRequired
 };
 
-export default MapLegend;
+export default injectIntl(MapLegend);

--- a/src/components/MapLegend/index.js
+++ b/src/components/MapLegend/index.js
@@ -1,12 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import { FormattedMessage } from 'react-intl';
 import { Checkbox } from '../../shared/components/checkbox';
 
 import CollapseIcon from '../../images/icon-arrow-down.svg';
 import ExpandIcon from '../../images/icon-arrow-up.svg';
 import MapLayersIcon from '../../images/icon-map-layers.svg';
 
+import messages from './messages';
 import './style.scss';
 
 class MapLegend extends React.Component {
@@ -45,7 +47,9 @@ class MapLegend extends React.Component {
           title={this.state.isLegendVisible ? 'Kaartlagen verbergen' : 'Kaartlagen tonen'}
         >
           <MapLayersIcon className="map-legend__header-icon" />
-          <h4 className="map-legend__header-title" aria-hidden="true">Apparaten</h4>
+          <h4 className="map-legend__header-title" aria-hidden="true">
+            <FormattedMessage {...messages.header} />
+          </h4>
           <CollapseIcon className="map-legend__header-icon map-legend__header-icon--expanded" />
           <ExpandIcon className="map-legend__header-icon map-legend__header-icon--collapsed" />
         </button>

--- a/src/components/MapLegend/messages.js
+++ b/src/components/MapLegend/messages.js
@@ -5,11 +5,27 @@
  */
 import { defineMessages } from 'react-intl';
 
-export const scope = 'boilerplate.components.MapLegend';
+export const scope = 'IoTRegister.components.MapLegend';
 
 export default defineMessages({
   header: {
     id: `${scope}.header`,
     defaultMessage: 'Devices',
+  },
+  legendHide: {
+    id: `${scope}.legend.hide`,
+    defaultMessage: 'Map Legend, Hide Legend',
+  },
+  legendShow: {
+    id: `${scope}.legend.show`,
+    defaultMessage: 'Map Legend, Show Legend',
+  },
+  hide: {
+    id: `${scope}.hide`,
+    defaultMessage: 'Hide Legend',
+  },
+  show: {
+    id: `${scope}.show`,
+    defaultMessage: 'Show Legend',
   }
 });

--- a/src/components/MapLegend/messages.js
+++ b/src/components/MapLegend/messages.js
@@ -1,0 +1,15 @@
+/*
+ * Map Legend Messages
+ *
+ * This contains all the text for the MapLegend component.
+ */
+import { defineMessages } from 'react-intl';
+
+export const scope = 'boilerplate.components.MapLegend';
+
+export default defineMessages({
+  header: {
+    id: `${scope}.header`,
+    defaultMessage: 'Devices',
+  }
+});

--- a/src/containers/NotFoundPage/index.test.js
+++ b/src/containers/NotFoundPage/index.test.js
@@ -16,7 +16,7 @@ describe('<NotFound />', () => {
     expect(renderedComponent.contains(
       <h1>
         <FormattedMessage
-          id="boilerplate.containers.NotFoundPage.header"
+          id="IoTRegister.containers.NotFoundPage.header"
           defaultMessage={'Page not found.'}
         />
       </h1>)).toEqual(true);

--- a/src/containers/NotFoundPage/messages.js
+++ b/src/containers/NotFoundPage/messages.js
@@ -7,7 +7,7 @@ import { defineMessages } from 'react-intl';
 
 export default defineMessages({
   header: {
-    id: 'boilerplate.containers.NotFoundPage.header',
+    id: 'IoTRegister.containers.NotFoundPage.header',
     defaultMessage: 'Page not found.',
   },
 });

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -7,18 +7,22 @@
 import { addLocaleData } from 'react-intl';
 import enLocaleData from 'react-intl/locale-data/en';
 import nlLocaleData from 'react-intl/locale-data/nl';
+import daLocaleData from 'react-intl/locale-data/da';
 
 import { DEFAULT_LOCALE } from '../src/containers/App/constants';
 
 import enTranslationMessages from './translations/en.json';
 import nlTranslationMessages from './translations/nl.json';
+import daTranslationMessages from './translations/da.json';
 
 addLocaleData(enLocaleData);
 addLocaleData(nlLocaleData);
+addLocaleData(daLocaleData);
 
 export const appLocales = [
   'en',
   'nl',
+  'da',
 ];
 
 export const formatTranslationMessages = (locale, messages) => {
@@ -36,4 +40,5 @@ export const formatTranslationMessages = (locale, messages) => {
 export const translationMessages = {
   en: formatTranslationMessages('en', enTranslationMessages),
   nl: formatTranslationMessages('nl', nlTranslationMessages),
+  da: formatTranslationMessages('da', daTranslationMessages),
 };

--- a/src/translations/da.json
+++ b/src/translations/da.json
@@ -1,5 +1,9 @@
 {
-  "boilerplate.components.Header.home": "Hjem",
-  "boilerplate.components.MapLegend.header": "Enheder",
-  "boilerplate.containers.NotFoundPage.header": "Siden ikke fundet."
+  "IoTRegister.components.Header.home": "Hjem",
+  "IoTRegister.components.MapLegend.header": "IoT Enheder",
+  "IoTRegister.components.MapLegend.hide": "Gem Tegnforklaring",
+  "IoTRegister.components.MapLegend.legend.hide": "Tegnforklaring, Gem Tegnforklaring",
+  "IoTRegister.components.MapLegend.legend.show": "Tegnforklaring, Vis Tegnforklaring",
+  "IoTRegister.components.MapLegend.show": "Vis Tegnforklaring",
+  "IoTRegister.containers.NotFoundPage.header": "Siden ikke fundet."
 }

--- a/src/translations/da.json
+++ b/src/translations/da.json
@@ -1,0 +1,5 @@
+{
+  "boilerplate.components.Header.home": "Hjem",
+  "boilerplate.components.MapLegend.header": "Enheder",
+  "boilerplate.containers.NotFoundPage.header": "Siden ikke fundet."
+}

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1,5 +1,9 @@
 {
-  "boilerplate.components.Header.home": "Home",
-  "boilerplate.components.MapLegend.header": "Devices",
-  "boilerplate.containers.NotFoundPage.header": "Page not found."
+  "IoTRegister.components.Header.home": "Home",
+  "IoTRegister.components.MapLegend.header": "Devices",
+  "IoTRegister.components.MapLegend.hide": "Hide Legend",
+  "IoTRegister.components.MapLegend.legend.hide": "Map Legend, Hide Legend",
+  "IoTRegister.components.MapLegend.legend.show": "Map Legend, Show Legend",
+  "IoTRegister.components.MapLegend.show": "Show Legend",
+  "IoTRegister.containers.NotFoundPage.header": "Page not found."
 }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1,14 +1,5 @@
 {
-  "boilerplate.components.Footer.author.message": "Made with love by {author}.",
-  "boilerplate.components.Footer.license.message": "This project is licensed under the MIT license.",
-  "boilerplate.components.Header.features": "Features",
   "boilerplate.components.Header.home": "Home",
-  "boilerplate.containers.HomePage.start_project.header": "Start your next react project in seconds",
-  "boilerplate.containers.HomePage.start_project.message": "A highly scalable, offline-first foundation with the best DX and a focus on performance and best practices",
-  "boilerplate.containers.HomePage.tryme.atPrefix": "@",
-  "boilerplate.containers.HomePage.tryme.header": "Try me!",
-  "boilerplate.containers.HomePage.tryme.message": "Show Github repositories by",
-  "boilerplate.containers.LocaleToggle.nl": "nl",
-  "boilerplate.containers.LocaleToggle.en": "en",
+  "boilerplate.components.MapLegend.header": "Devices",
   "boilerplate.containers.NotFoundPage.header": "Page not found."
 }

--- a/src/translations/nl.json
+++ b/src/translations/nl.json
@@ -1,5 +1,9 @@
 {
-  "boilerplate.components.Header.home": "",
-  "boilerplate.components.MapLegend.header": "Apparaten",
-  "boilerplate.containers.NotFoundPage.header": "Pagina niet gevonden."
+  "IoTRegister.components.Header.home": "",
+  "IoTRegister.components.MapLegend.header": "Apparaten",
+  "IoTRegister.components.MapLegend.hide": "Kaartlagen verbergen",
+  "IoTRegister.components.MapLegend.legend.hide": "Kaartlagen legenda, Kaartlagen verbergen",
+  "IoTRegister.components.MapLegend.legend.show": "Kaartlagen legenda, Kaartlagen tonen",
+  "IoTRegister.components.MapLegend.show": "Kaartlagen tonen",
+  "IoTRegister.containers.NotFoundPage.header": "Pagina niet gevonden."
 }

--- a/src/translations/nl.json
+++ b/src/translations/nl.json
@@ -1,11 +1,5 @@
 {
-  "boilerplate.components.Footer.author.message": "Met liefde gemaakt door {author}.",
-  "boilerplate.components.Footer.license.message": "Dit project valt onder Mozilla Public License 2.0.",
-  "boilerplate.components.Header.features": "",
   "boilerplate.components.Header.home": "",
-  "boilerplate.containers.HomePage.start_project.header": "Welkom bij Gemeente Amsterdam",
-  "boilerplate.containers.HomePage.start_project.message": "Ontwikkeld door Datapunt Amsterdam",
-  "boilerplate.containers.LocaleToggle.nl": "",
-  "boilerplate.containers.LocaleToggle.en": "",
+  "boilerplate.components.MapLegend.header": "Apparaten",
   "boilerplate.containers.NotFoundPage.header": "Pagina niet gevonden."
 }


### PR DESCRIPTION
Looking into using the IoTRegister in a danish context. To do that the app will need to be i18n ready.
For now this is a proof of concept for allowing i18n in the various components. 

It seems that while the `react-boilerplate` setup includes a i18n setup, that this has been deactived and not used in the apps components. Is there a reason for this (performance, compatibility, or other) that I should be aware of or has the need just not been there yet?

As a proof of concept I have refactored the `MapLegend` component to be translatable and added messages for danish and English, while reusing the dutch messages. I would like your input as to weather you agree with this approach?

