### PR TITLE
OP-601 Fix marker boundary visible after zoom out

### DIFF
--- a/src/components/MapInteractive/index.js
+++ b/src/components/MapInteractive/index.js
@@ -79,7 +79,7 @@ class Map extends React.Component {
 
   async addMarkers() {
     this.devices = await getDevices();
-    showMarkers(this.map, this.devices, this.showDevice.bind(this));
+    showMarkers(this.map, this.devices, this.showDevice.bind(this), this.clearSelection.bind(this));
   }
 
   showCameraArea(areaDetails) { // eslint-disable-line no-unused-vars

--- a/src/components/MapInteractive/index.js
+++ b/src/components/MapInteractive/index.js
@@ -79,7 +79,7 @@ class Map extends React.Component {
 
   async addMarkers() {
     this.devices = await getDevices();
-    showMarkers(this.map, this.devices, this.showDevice.bind(this), this.clearSelection.bind(this));
+    showMarkers(this.map, this.devices, this.showDevice.bind(this));
   }
 
   showCameraArea(areaDetails) { // eslint-disable-line no-unused-vars

--- a/src/components/MapInteractive/style.scss
+++ b/src/components/MapInteractive/style.scss
@@ -153,3 +153,8 @@ path.camera-area {
     display: none;
   }
 }
+
+.leaflet-marker-icon.highlight {
+  box-shadow: 0 0 0 3px rgba(0,0,0,0.8);
+  border-radius: 50%;
+}

--- a/src/services/iotmap.js
+++ b/src/services/iotmap.js
@@ -77,7 +77,7 @@ export const removeCurrentHighlight = (map) => {
   }
 };
 
-export function showMarkers(map, markers, onClick, onRemove) {
+export function showMarkers(map, markers, onClick) {
   const showInfo = (event, loc) => {
     if (activeMarker) {
       activeMarker._icon.classList.remove('highlight');
@@ -106,7 +106,7 @@ export function showMarkers(map, markers, onClick, onRemove) {
           icon: getMarkerIcon(marker),
         })
           .addTo(layer)
-          .on('add', (event) => {
+          .once('add', (event) => {
             const { sourceTarget } = event;
 
             if (activeMarker && sourceTarget._latlng === activeMarker._latlng) {
@@ -114,12 +114,11 @@ export function showMarkers(map, markers, onClick, onRemove) {
             }
             return this;
           })
-          .on('remove', (event) => {
+          .once('remove', (event) => {
             const { sourceTarget } = event;
 
             if (activeMarker && sourceTarget._latlng === activeMarker._latlng) {
               activeMarker = undefined;
-              onRemove();
             }
             return this;
           })


### PR DESCRIPTION
This PR fixes an issue where, when a marker was clicked and the map was zoomed out, the marker boundary wasn't in the right position or was still visible where the marker wasn't visible.
To accomplish that, listeners for the `add` and `remove` events are added. Instead of placing an extra marker on the map, the active marker is styled differently so that its image gets a box-shadow.