### PR TITLE
(Fix) Webpack errors

### DIFF
--- a/internals/webpack/webpack.base.babel.js
+++ b/internals/webpack/webpack.base.babel.js
@@ -117,7 +117,7 @@ module.exports = (options) => ({
     ],
   },
   devtool: options.devtool,
-  target: 'web', // Make web variables accessible to webpack, e.g. window
+  target: options.target || 'web', // Make web variables accessible to webpack, e.g. window
   performance: options.performance || {},
   externals: {
     globalConfig: JSON.stringify(require(path.resolve(process.cwd(),'environment.conf.json'))), //eslint-disable-line

--- a/internals/webpack/webpack.dll.babel.js
+++ b/internals/webpack/webpack.dll.babel.js
@@ -20,6 +20,7 @@ const dllConfig = defaults(pkg.dllPlugin, dllPlugin.defaults);
 const outputPath = join(process.cwd(), dllConfig.path);
 
 module.exports = require('./webpack.base.babel')({
+  target: 'node',
   context: process.cwd(),
   entry: dllConfig.dlls ? dllConfig.dlls : dllPlugin.entry(pkg),
   devtool: 'eval',

--- a/package.json
+++ b/package.json
@@ -181,7 +181,8 @@
       "cross-env",
       "express",
       "ip",
-      "minimist"
+      "minimist",
+      "amsterdam-stijl"
     ],
     "include": [
       "core-js",


### PR DESCRIPTION
This PR fixes the following errors when installing the project:
```
ERROR in dll reactBoilerplateDeps
Module not found: Error: Can't resolve 'amsterdam-stijl' in '/Volumes/projects/Amsterdam/register-slimme-apparaten-frontend'
 @ dll reactBoilerplateDeps

ERROR in ./node_modules/babel-plugin-inline-react-svg/lib/index.js
Module not found: Error: Can't resolve 'fs' in '/Volumes/projects/Amsterdam/register-slimme-apparaten-frontend/node_modules/babel-plugin-inline-react-svg/lib'
 @ ./node_modules/babel-plugin-inline-react-svg/lib/index.js 7:10-23
 @ dll reactBoilerplateDeps

ERROR in ./node_modules/babel-plugin-inline-react-svg/lib/fileExistsWithCaseSync.js
Module not found: Error: Can't resolve 'fs' in '/Volumes/projects/Amsterdam/register-slimme-apparaten-frontend/node_modules/babel-plugin-inline-react-svg/lib'
 @ ./node_modules/babel-plugin-inline-react-svg/lib/fileExistsWithCaseSync.js 5:9-22
 @ ./node_modules/babel-plugin-inline-react-svg/lib/index.js
 @ dll reactBoilerplateDeps

ERROR in ./node_modules/resolve/lib/async.js
Module not found: Error: Can't resolve 'fs' in '/Volumes/projects/Amsterdam/register-slimme-apparaten-frontend/node_modules/resolve/lib'
 @ ./node_modules/resolve/lib/async.js 2:9-22
 @ ./node_modules/resolve/index.js
 @ ./node_modules/babel-plugin-inline-react-svg/lib/index.js
 @ dll reactBoilerplateDeps

ERROR in ./node_modules/resolve/lib/sync.js
Module not found: Error: Can't resolve 'fs' in '/Volumes/projects/Amsterdam/register-slimme-apparaten-frontend/node_modules/resolve/lib'
 @ ./node_modules/resolve/lib/sync.js 2:9-22
 @ ./node_modules/resolve/index.js
 @ ./node_modules/babel-plugin-inline-react-svg/lib/index.js
 @ dll reactBoilerplateDeps

ERROR in ./node_modules/resolve/lib/node-modules-paths.js
Module not found: Error: Can't resolve 'fs' in '/Volumes/projects/Amsterdam/register-slimme-apparaten-frontend/node_modules/resolve/lib'
 @ ./node_modules/resolve/lib/node-modules-paths.js 2:9-22
 @ ./node_modules/resolve/lib/sync.js
 @ ./node_modules/resolve/index.js
 @ ./node_modules/babel-plugin-inline-react-svg/lib/index.js
 @ dll reactBoilerplateDeps

ERROR in ./node_modules/svgo/lib/svgo/config.js
Module not found: Error: Can't resolve 'fs' in '/Volumes/projects/Amsterdam/register-slimme-apparaten-frontend/node_modules/svgo/lib/svgo'
 @ ./node_modules/svgo/lib/svgo/config.js 3:9-22
 @ ./node_modules/svgo/lib/svgo.js
 @ ./node_modules/babel-plugin-inline-react-svg/lib/optimize.js
 @ ./node_modules/babel-plugin-inline-react-svg/lib/index.js
 @ dll reactBoilerplateDeps
```