### PR TITLE
(Fix) Increase Docker Node version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM node:8.9 AS builder
+FROM node:8.15-stretch AS builder
 LABEL maintainer="datapunt@amsterdam.nl"
 
 ARG BUILD_ENV=prod
@@ -58,4 +58,3 @@ COPY default.conf /etc/nginx/conf.d/
 # forward request and error logs to docker log collector
 RUN ln -sf /dev/stdout /var/log/nginx/access.log \
 	&& ln -sf /dev/stderr /var/log/nginx/error.log
-


### PR DESCRIPTION
This PR increase the Node version in the `Dockerfile` to overcome not being able to download discontinued Debian packages.