### PR TITLE
(Chore) Remove category

### DIFF
--- a/src/components/MapInteractive/index.js
+++ b/src/components/MapInteractive/index.js
@@ -15,6 +15,14 @@ import CameraAreaDetails from '../CameraAreaDetails';
 
 import './style.scss';
 
+const visibleCategories = { ...categories };
+
+Object.keys(visibleCategories)
+  .filter((cat) => !(visibleCategories[cat].visible && visibleCategories[cat].enabled))
+  .forEach((cat) => {
+    delete visibleCategories[cat];
+  });
+
 const DEFAULT_ZOOM_LEVEL = 14;
 
 const SELECTION_STATE = {
@@ -106,14 +114,6 @@ class Map extends React.Component {
         <button className="about-button" onClick={() => { history.push('/about'); }}>Over dit register</button>
       )}
     />);
-
-    const visibleCategories = { ...categories };
-
-    Object.keys(visibleCategories)
-      .filter((cat) => !(visibleCategories[cat].visible && visibleCategories[cat].enabled))
-      .forEach((cat) => {
-        delete visibleCategories[cat];
-      });
 
     return (
       <div className="map-component">

--- a/src/static/categories.js
+++ b/src/static/categories.js
@@ -84,7 +84,7 @@ const categories = {
     wikipediaUrl: '',
     wikipediaDescription: '',
     subtypes: [],
-    visible: true,
+    visible: false,
   }
 };
 


### PR DESCRIPTION
This PR:
- removes category 'Slimme lantaarnpaal' from the list of visible categories (which will effectively hide it from the map legend, but not on the category page)
- moves the list of filtered categories from the `MapInteractive` component's render function; on re-render the list was filtered again and returned an unwanted result