### PR TITLE
fix: reverse longitude and latitude

### DIFF
--- a/src/components/DeviceDetails/index.tsx
+++ b/src/components/DeviceDetails/index.tsx
@@ -21,7 +21,8 @@ const DeviceDetails: React.FC<Props> = ({ feature }) => {
     return null;
   }
 
-  const { category, sensorType, organisation, privacy, contact, activeUntil, goal, legalGround } = feature.properties;
+  const { category, sensorType, organisation, privacy, contact, activeUntil, goal, legalGround, reference } =
+    feature.properties;
 
   return (
     <section id="device-details">
@@ -43,6 +44,7 @@ const DeviceDetails: React.FC<Props> = ({ feature }) => {
         <h3>Sensorgegevens</h3>
         <List variant="bullet">
           <ListItem>{sensorType}</ListItem>
+          {reference && <ListItem>Referentie: {reference}</ListItem>}
         </List>
       </InfoContainer>
 

--- a/src/containers/MapContainer/index.tsx
+++ b/src/containers/MapContainer/index.tsx
@@ -121,14 +121,7 @@ const MapContainer: () => JSX.Element = () => {
         onControlClick={() => setLegendOrDetails(LegendOrDetails.LEGEND)}
       >
         <DrawerContentWrapper>
-          {legendOrDetails === LegendOrDetails.DETAILS && (
-            <DeviceDetails
-              feature={selectedItem}
-              onDeviceDetailsClose={() => {
-                setLegendOrDetails(LegendOrDetails.LEGEND);
-              }}
-            />
-          )}
+          {legendOrDetails === LegendOrDetails.DETAILS && <DeviceDetails feature={selectedItem} />}
 
           {legendOrDetails === LegendOrDetails.LEGEND && (
             <MapLegend

--- a/src/services/layer-aggregator/layersConfig.js
+++ b/src/services/layer-aggregator/layersConfig.js
@@ -12,7 +12,7 @@ const LAYERS_CONFIG = [
       type: 'Feature',
       geometry: {
         type: 'Point',
-        coordinates: [item.location.latitude, item.location.longitude],
+        coordinates: [item.location.longitude, item.location.latitude], // See also: https://datatracker.ietf.org/doc/html/rfc7946#section-3.1
       },
       properties: {
         privacy: item.privacy_declaration,

--- a/src/services/layer-aggregator/layersConfig.js
+++ b/src/services/layer-aggregator/layersConfig.js
@@ -28,6 +28,7 @@ const LAYERS_CONFIG = [
         goal: item.observation_goal,
         legalGround: item.legal_ground,
         originalData: item,
+        reference: item?.reference,
       },
     }),
   },


### PR DESCRIPTION
The API of the new register was sending latitude as longitude and vice versa. Our code was setup to deal with this difference. This PR updates the code to deal with the API correctly sending longitude and latitude.

We follow the GEOJson spec: https://datatracker.ietf.org/doc/html/rfc7946#section-3.1

Also add's a referencenumber to device details display (if present).